### PR TITLE
Fix dice pip placement

### DIFF
--- a/dice.svg
+++ b/dice.svg
@@ -1,23 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
-  <g transform="translate(10,10)">
-    <!-- top -->
-    <polygon points="40,0 80,20 40,40 0,20" fill="#fff" stroke="#000" />
-    <!-- front -->
-    <polygon points="0,20 40,40 40,80 0,60" fill="#f8f8f8" stroke="#000" />
-    <!-- right -->
-    <polygon points="40,40 80,20 80,60 40,80" fill="#e0e0e0" stroke="#000" />
-    <!-- pips top (showing 3) -->
-    <circle cx="25" cy="15" r="4" />
-    <circle cx="40" cy="25" r="4" />
-    <circle cx="55" cy="15" r="4" />
-    <!-- pips front (showing 5) -->
-    <circle cx="15" cy="35" r="4" />
-    <circle cx="30" cy="50" r="4" />
-    <circle cx="15" cy="65" r="4" />
-    <circle cx="35" cy="35" r="4" />
-    <circle cx="35" cy="65" r="4" />
-    <!-- pips right (showing 2) -->
-    <circle cx="55" cy="55" r="4" />
-    <circle cx="70" cy="70" r="4" />
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="5" y="5" width="90" height="90" rx="15" ry="15" fill="#fff" stroke="#000" stroke-width="5"/>
+  <circle cx="30" cy="30" r="7" fill="#000"/>
+  <circle cx="30" cy="50" r="7" fill="#000"/>
+  <circle cx="30" cy="70" r="7" fill="#000"/>
+  <circle cx="70" cy="30" r="7" fill="#000"/>
+  <circle cx="70" cy="50" r="7" fill="#000"/>
+  <circle cx="70" cy="70" r="7" fill="#000"/>
 </svg>


### PR DESCRIPTION
## Summary
- redraw dice as a flat square with six correctly placed pips

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b487289f8832da8fa2cd3a057eed2